### PR TITLE
Change to latest Keyrock RC8 image tag

### DIFF
--- a/PacketDelivery-ReferenceExample/Data-Service-Consumer/values/values-keyrock.yml
+++ b/PacketDelivery-ReferenceExample/Data-Service-Consumer/values/values-keyrock.yml
@@ -12,7 +12,7 @@ statefulset:
     ## ref: https://hub.docker.com/r/fiware/idm
     repository: fiware/idm
     ## tag of the image to be used
-    tag: i4trust-rc7-header-size
+    tag: i4trust-rc8
     ## specification of the image pull policy
     pullPolicy: IfNotPresent
     

--- a/PacketDelivery-ReferenceExample/Data-Service-Provider/values/values-keyrock.yml
+++ b/PacketDelivery-ReferenceExample/Data-Service-Provider/values/values-keyrock.yml
@@ -12,7 +12,7 @@ statefulset:
     ## ref: https://hub.docker.com/r/fiware/idm
     repository: fiware/idm
     ## tag of the image to be used
-    tag: i4trust-rc7-header-size
+    tag: i4trust-rc8
     ## specification of the image pull policy
     pullPolicy: IfNotPresent
     

--- a/PacketDelivery-ReferenceExample/i4Trust-Marketplace/values/values-keyrock.yml
+++ b/PacketDelivery-ReferenceExample/i4Trust-Marketplace/values/values-keyrock.yml
@@ -12,7 +12,7 @@ statefulset:
     ## ref: https://hub.docker.com/r/fiware/idm
     repository: fiware/idm
     ## tag of the image to be used
-    tag: i4trust-rc7
+    tag: i4trust-rc8
     ## specification of the image pull policy
     pullPolicy: IfNotPresent
     


### PR DESCRIPTION
This Keyrock build addresses the following issues:
* Allows to configure the maximum header size of incoming requests (might be required to use Keyrock as AR)
* Fixes an issue with the 'aud' scope when requesting access tokens at different satellites instead of the public iSHARE test instance